### PR TITLE
Remove P4 in summary

### DIFF
--- a/labels.md
+++ b/labels.md
@@ -68,6 +68,6 @@ It's recommended that you don't use status and tracking flag tags in GitHub issu
 * Regressions
 	* `regression`, `regressionwindow-wanted`, `regression-internal`
 * Priority
-	* `P1`, `P2`, `P3`, `P4`, `P5`
+	* `P1`, `P2`, `P3`, `P5`
 * Other keywords
 	* `enhancement`, `good first bug`


### PR DESCRIPTION
As P4 is unused, a label for it should not be needed.